### PR TITLE
increase almanax reliability

### DIFF
--- a/src/main/java/data/Constants.java
+++ b/src/main/java/data/Constants.java
@@ -147,12 +147,12 @@ public class Constants {
     /**
      * Almanax API URL
      */
-    public final static String almanaxURL = "https://alm.dofusdu.de/{game}/{language}/{date}";
+    public final static String almanaxURL = "https://alm.dofusdu.de/{game}/v1/{language}/{date}";
 
     /**
      * Almanax Redis cache time to live for each cached day
      */
-    public final static int almanaxCacheDaysTTL = 9;
+    public final static int almanaxCacheHoursTTL = 3;
 
     /**
      * Discord invite link


### PR DESCRIPTION
Fixes 2 known problems with the Almanax service.

**Ankama sometimes changes the offering for the next day but Kaelly serves the old offering.**
The API will now check every 2 hours if Ankama changed the offering and update the changed entries. Since Kaelly caches the results for 9 days, the chances are high it doesn't update. This is fixed by decreasing the time to live inside the cache to 3 hours. While this increases outside traffic and with that a little bit latency, it can handle short term updates to the Almanax.

**Offerings with items unknown to the encyclopedia.**
This happened on 2021-12-16 and will happen again on 2021-12-25 and 2 more days in the following weeks. The API now searches for a 100% hit in the encyclopedia and if it doesn't find an item, it will serve the mentioned item name on the Almanax site as a backup without meta information. Since the item image depends on the encyclopedia entry, there is also no guarantee for an image so we ignore it in that case. There can be an image url on the Almanax site but that has a high chance of resulting in a 404.

Additional, Kaelly now uses the versioned Almanax API /v1 to be more stable for long term updates.

<img width="593" alt="almanax demo with and without encyclopedia link" src="https://user-images.githubusercontent.com/40026170/146671821-a4ed7583-4fd6-4cec-a3a7-b7ff29d94950.png">
