### PR TITLE
Almanax API update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/data/Constants.java
+++ b/src/main/java/data/Constants.java
@@ -1,3 +1,4 @@
+
 package data;
 
 import enums.Game;
@@ -147,7 +148,7 @@ public class Constants {
     /**
      * Almanax API URL
      */
-    public final static String almanaxURL = "https://alm.dofusdu.de/{game}/v1/{language}/{date}";
+    public final static String almanaxURL = "https://api.dofusdu.de/{game}/{language}/almanax/{date}";
 
     /**
      * Almanax Redis cache time to live for each cached day


### PR DESCRIPTION
The currently used endpoint returns an ankama_url bound to the Dofus Encyclopedia website, which is known to give some problems like the to the Encyclopedia unknown Item on 2021-12-16.
The bot will fail scraping the data itself, since the image from Ankama is also 404 since it is not on their website.

With the new [API](https://docs.dofusdu.de), the data is not mapped to the online resources from Ankama anymore. But Kaelly currently wants to post links to the items. The old endpoint still works but the link is just to the general Encyclopedia, which can be frustrating for users.

Kaelly
<img width="610" alt="image" src="https://user-images.githubusercontent.com/40026170/189658979-b51e4da4-1c2c-4789-b540-37c27e446761.png">

Ankama Website
<img width="452" alt="image" src="https://user-images.githubusercontent.com/40026170/189659464-ce2c52d5-f613-417c-b735-1201e5f71e41.png">

